### PR TITLE
update unidecode dependency's import path

### DIFF
--- a/slug.go
+++ b/slug.go
@@ -6,7 +6,7 @@
 package slug
 
 import (
-	"github.com/fiam/gounidecode/unidecode"
+	"gopkgs.com/unidecode.v1"
 	"regexp"
 	"strings"
 )


### PR DESCRIPTION
The old `unidecode` package in [`github.com/fiam/gounidecode/unidecode`](https://github.com/fiam/gounidecode) is [no longer maintained according to the package owner](https://github.com/fiam/gounidecode/issues/2). The package has moved to [gopkgs.com/unidecode.v1](http://gopkgs.com/unidecode.v1).

The current package's import path also causes bugs on Windows and Linux, which causes failed builds on services such as Gobuild.io, which is the main reason I'd hope you to merge this PR.
