### PR TITLE
Use a buffer instead of "naive" concatenation in SubstituteRune

### DIFF
--- a/slug.go
+++ b/slug.go
@@ -6,10 +6,9 @@
 package slug
 
 import (
+	"bytes"
 	"regexp"
 	"strings"
-
-	"bytes"
 
 	"github.com/rainycape/unidecode"
 )

--- a/slug.go
+++ b/slug.go
@@ -91,7 +91,7 @@ func Substitute(s string, sub map[string]string) (buf string) {
 
 // SubstituteRune substitutes string chars with provided rune
 // substitution map.
-func SubstituteRune(s string, sub map[rune]string) (result string) {
+func SubstituteRune(s string, sub map[rune]string) string {
 	var buf bytes.Buffer
 	for _, c := range s {
 		if d, ok := sub[c]; ok {

--- a/slug.go
+++ b/slug.go
@@ -9,6 +9,8 @@ import (
 	"regexp"
 	"strings"
 
+	"bytes"
+
 	"github.com/rainycape/unidecode"
 )
 
@@ -89,15 +91,16 @@ func Substitute(s string, sub map[string]string) (buf string) {
 
 // SubstituteRune substitutes string chars with provided rune
 // substitution map.
-func SubstituteRune(s string, sub map[rune]string) (buf string) {
+func SubstituteRune(s string, sub map[rune]string) (result string) {
+	var buf bytes.Buffer
 	for _, c := range s {
 		if d, ok := sub[c]; ok {
-			buf += d
+			buf.WriteString(d)
 		} else {
-			buf += string(c)
+			buf.WriteRune(c)
 		}
 	}
-	return
+	return buf.String()
 }
 
 func smartTruncate(text string) string {


### PR DESCRIPTION
Current string concatenation makes a lot of memory allocations. Using a buffer should be more efficient.

See : http://herman.asia/efficient-string-concatenation-in-go