### PR TITLE
slug: Solve issue for IsSlug and numbers

### DIFF
--- a/slug.go
+++ b/slug.go
@@ -142,7 +142,7 @@ func smartTruncate(text string) string {
 // All output from slug.Make(text) should pass this test.
 func IsSlug(text string) bool {
 	for _, c := range text {
-		if (c < 'a' || c > 'z') && c != '-' && c != '_' {
+		if (c < 'a' || c > 'z') && c != '-' && c != '_' && (c < '0' || c > '9') {
 			return false
 		}
 	}

--- a/slug_test.go
+++ b/slug_test.go
@@ -218,6 +218,7 @@ func TestIsSlug(t *testing.T) {
 		{"some", args{"some"}, true},
 		{"with -", args{"some-more"}, true},
 		{"with _", args{"some_more"}, true},
+		{"with numbers", args{"number-2"}, true},
 		{"upper case", args{"Some-more"}, false},
 		{"space", args{"some more"}, false},
 		{"outside ASCII", args{"Dobrosław Żybort"}, false},


### PR DESCRIPTION
It was counting numbers as invalid characters in a slug, and they are not.

As the description says, `[...]All output from slug.Make(text) shoud pass this test` and I've found that if the text contains a number, the IsSlug returns `false`, an example:

```go
package main

import (
	"fmt"

	"github.com/gosimple/slug"
)

func main() {
	text := "Some text 2 slugify"
	sl := slug.Make(text)
	fmt.Printf("Slugifyed text: %s\n", sl)
	fmt.Printf("(%s)IsSlug: %t\n", sl, slug.IsSlug(sl))
}
```
returns
``` 
Slugifyed text: some-text-2-slugify
(some-text-2-slugify)IsSlug: false
```