### PR TITLE
Substitute @ with at in german

### DIFF
--- a/languages_substitution.go
+++ b/languages_substitution.go
@@ -30,7 +30,7 @@ var defaultSub = map[rune]string{
 
 var deSub = map[rune]string{
 	'&': "und",
-	'@': "an",
+	'@': "at",
 	'ä': "ae",
 	'Ä': "Ae",
 	'ö': "oe",


### PR DESCRIPTION
I would suggest replacing the character `@` with `at`. To be honest, I've never heard anyone say "xyz AN gmail.com" while providing their email address.