### PR TITLE
Add Italian language substitutions

### DIFF
--- a/languages_substitution.go
+++ b/languages_substitution.go
@@ -19,6 +19,7 @@ func init() {
 		&grSub,
 		&huSub,
 		&idSub,
+		&itSub,
 		&kkSub,
 		&nbSub,
 		&nlSub,
@@ -120,6 +121,11 @@ var huSub = map[rune]string{
 
 var idSub = map[rune]string{
 	'&': "dan",
+}
+
+var itSub = map[rune]string{
+	'&': "e",
+	'@': "chiocciola",
 }
 
 var kkSub = map[rune]string{

--- a/slug.go
+++ b/slug.go
@@ -75,6 +75,8 @@ func MakeLang(s string, lang string) (slug string) {
 		slug = SubstituteRune(slug, huSub)
 	case "id", "idn", "ind":
 		slug = SubstituteRune(slug, idSub)
+	case "it", "ita":
+		slug = SubstituteRune(slug, itSub)
 	case "kz", "kk", "kaz":
 		slug = SubstituteRune(slug, kkSub)
 	case "nb", "nob":

--- a/slug_test.go
+++ b/slug_test.go
@@ -111,6 +111,8 @@ func TestSlugMakeLang(t *testing.T) {
 		{"fr", "This @ that", "this-arobase-that", true},
 		{"gr", "This & that", "this-kai-that", true},
 		{"id", "This & that", "this-dan-that", true},
+		{"it", "This & that", "this-e-that", true},
+		{"it", "This @ that", "this-chiocciola-that", true},
 		{"ell", "This & that", "this-kai-that", true},
 		{"Ell", "This & that", "this-kai-that", true},
 		{"kk", "This & that", "this-jane-that", true},


### PR DESCRIPTION
Substitutions:
- _&_ -> _e_ (https://dictionary.cambridge.org/dictionary/english-italian/and)
- _@_ -> _chiocciola_ (https://dictionary.cambridge.org/dictionary/english-italian/at-sign)
