### PR TITLE
fix edge case in truncate function allowing too long slugs

### DIFF
--- a/slug.go
+++ b/slug.go
@@ -150,21 +150,15 @@ func smartTruncate(text string) string {
 		return text
 	}
 
-	var truncated string
-	words := strings.SplitAfter(text, "-")
-	// If MaxLength is smaller than length of the first word return word
-	// truncated after MaxLength.
-	if len(words[0]) > MaxLength {
-		return words[0][:MaxLength]
-	}
-	for _, word := range words {
-		if len(truncated)+len(word)-1 <= MaxLength {
-			truncated = truncated + word
-		} else {
-			break
+	// If slug is too long, we need to find the last '-' before MaxLength, and
+	// we cut there.
+	// If we don't find any, we have only one word, and we cut at MaxLength.
+	for i := MaxLength - 1; i >= 0; i-- {
+		if text[i] == '-' {
+			return text[:i]
 		}
 	}
-	return strings.Trim(truncated, "-")
+	return text[:MaxLength]
 }
 
 // IsSlug returns True if provided text does not contain white characters,

--- a/slug_test.go
+++ b/slug_test.go
@@ -273,6 +273,7 @@ func TestSlugMakeSmartTruncate(t *testing.T) {
 		{"DOBROSLAWZYBORT", 100, "dobroslawzybort"},
 		{"Dobroslaw Zybort", 100, "dobroslaw-zybort"},
 		{"Dobroslaw Zybort", 12, "dobroslaw"},
+		{"Dobroslaw Zybort", 15, "dobroslaw"},
 		{"  Dobroslaw     Zybort  ?", 12, "dobroslaw"},
 		{"Ala ma 6 kotów.", 10, "ala-ma-6"},
 		{"Dobrosław Żybort", 5, "dobro"},


### PR DESCRIPTION
Fixes https://github.com/gosimple/slug/issues/72

I'm not using operations on strings to avoid unnecessary allocations.
I've added a test case for the fixed issue.