### PR TITLE
Fixed truncation issue

### DIFF
--- a/slug.go
+++ b/slug.go
@@ -112,7 +112,7 @@ func MakeLang(s string, lang string) (slug string) {
 		slug = strings.ToLower(slug)
 	}
 
-	if !EnableSmartTruncate {
+	if !EnableSmartTruncate && len(slug) >= MaxLength {
 		slug = slug[:MaxLength]
 	}
 

--- a/slug_test.go
+++ b/slug_test.go
@@ -288,6 +288,7 @@ func TestSlugMakeSmartTruncate(t *testing.T) {
 		{"Dobroslaw Zybort", 9, "dobroslaw", true},
 		{"Dobroslaw Zybort", 12, "dobroslaw", true},
 		{"Dobroslaw Zybort", 15, "dobroslaw", true},
+		{"Dobroslaw Zybort", 15, "dobroslaw-zybor", false},
 		{"Dobroslaw Zybort", 16, "dobroslaw-zybort", true},
 		{"Dobroslaw Zybort", 17, "dobroslaw-zybort", true},
 		{"Dobroslaw Zybort", 100, "dobroslaw-zybort", true},
@@ -312,6 +313,7 @@ func TestSlugMakeSmartTruncate(t *testing.T) {
 
 		{"DOBROSLAWZYBORT", 9, "dobroslaw", true},
 		{"DOBROSLAWZYBORT", 15, "dobroslawzybort", true},
+		{"DOBROSLAWZYBORT", 17, "dobroslawzybort", false},
 		{"DOBROSLAWZYBORT", 100, "dobroslawzybort", true},
 		{"  Dobroslaw     Zybort  ?", 12, "dobroslaw", true},
 		{"Ala ma 6 kotów.", 10, "ala-ma-6", true},


### PR DESCRIPTION
https://github.com/gosimple/slug/issues/76 
"
When trying to truncate a string with a value greater than its size, we get the below error.

Example of failed test: `{"DOBROSLAWZYBORT", 17, "dobroslawzybort", false}`

```
--- FAIL: TestSlugMakeSmartTruncate (0.01s)
panic: runtime error: slice bounds out of range [:17] with length 15 [recovered]
	panic: runtime error: slice bounds out of range [:17] with length 15
```
"