### PR TITLE
Add AppendTimestamp option to make slug unique

### DIFF
--- a/slug.go
+++ b/slug.go
@@ -9,7 +9,9 @@ import (
 	"bytes"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gosimple/unidecode"
 )
@@ -35,6 +37,10 @@ var (
 	// Lowercase defines if the resulting slug is transformed to lowercase.
 	// Default is true.
 	Lowercase = true
+
+	// Append timestamp to the end in order to make slug unique
+	// Default is false
+	AppendTimestamp = false
 
 	regexpNonAuthorizedChars = regexp.MustCompile("[^a-zA-Z0-9-_]")
 	regexpMultipleDashes     = regexp.MustCompile("-+")
@@ -127,6 +133,10 @@ func MakeLang(s string, lang string) (slug string) {
 		slug = smartTruncate(slug)
 	}
 
+	if AppendTimestamp {
+		slug = slug + "-" + timestamp()
+	}
+
 	return slug
 }
 
@@ -175,6 +185,11 @@ func smartTruncate(text string) string {
 		}
 	}
 	return text[:MaxLength]
+}
+
+// timestamp returns current timestamp as string
+func timestamp() string {
+	return strconv.FormatInt(time.Now().Unix(), 10)
 }
 
 // IsSlug returns True if provided text does not contain white characters,

--- a/slug_test.go
+++ b/slug_test.go
@@ -399,6 +399,11 @@ func TestSlugMakeAppendTimestamp(t *testing.T) {
 		{"Ala ma 6 kotów.", "ala-ma-6-kotow", false},
 	}
 
+	MaxLength = 0
+	EnableSmartTruncate = true
+	CustomRuneSub = nil
+	CustomSub = nil
+	Lowercase = true
 	for index, st := range testCases {
 		if st.appendTimestamp {
 			AppendTimestamp = true


### PR DESCRIPTION
Slugs may need to be unique.

Add `AppendTimestamp` option to ensure a slug is unique.

When `AppendTimestamp` is set to `true`, the final slug will be added a dash (`-`) and ten-digit numbers represent the current timestamp.