### PR TITLE
Fix some order dependent tests

### DIFF
--- a/slug_test.go
+++ b/slug_test.go
@@ -203,6 +203,7 @@ func TestSlugMakeUserSubstituteLang(t *testing.T) {
 				got, smust.want)
 		}
 	}
+	CustomSub = nil
 }
 
 func TestSlugMakeSubstituteOrderLang(t *testing.T) {
@@ -230,6 +231,8 @@ func TestSlugMakeSubstituteOrderLang(t *testing.T) {
 				got, smsot.want)
 		}
 	}
+	CustomRuneSub = nil
+	CustomSub = nil
 }
 
 func TestSubstituteLang(t *testing.T) {


### PR DESCRIPTION
These tests were modifying global state and not resetting it. Clearing the CustomSub lets the tests run in any order.